### PR TITLE
Ensure the AppStream data can be used for the repo's appstream branch

### DIFF
--- a/org.gnome.Weather.json
+++ b/org.gnome.Weather.json
@@ -5,6 +5,7 @@
   "runtime-version" : "3.22",
   "sdk" : "org.gnome.Sdk",
   "command" : "gnome-weather",
+  "rename-appdata-file": "org.gnome.Weather.Application.appdata.xml",
   "finish-args" : [
     "--share=ipc",
     "--socket=x11",


### PR DESCRIPTION
The build-update-repo command expects a file like <id>.appdata.xml, which
is not the case for GNOME Weather, make sure it gets renamed when creating
the bundle. Upstream bug: https://bugzilla.gnome.org/show_bug.cgi?id=777052

https://phabricator.endlessm.com/T14669