### PR TITLE
Use the plain git protocol for the module source checkout

### DIFF
--- a/org.gnome.Weather.json
+++ b/org.gnome.Weather.json
@@ -72,7 +72,7 @@
       "name" : "gnome-weather",
       "sources" : [
         {
-          "url": "https://github.com/endlessm/gnome-weather.git",
+          "url": "git://github.com/endlessm/gnome-weather",
           "branch": "master",
 	  "type": "git"
         }


### PR DESCRIPTION
This gives a temporary fix for the "invalid ssl" issue
when doing the checkout from within the sandbox.

This will only allow for pulling from the repository,
but should be ok for now for the CodeView use case.

https://phabricator.endlessm.com/T15579