### PR TITLE
Allow owning org.gnome.Weather.BackgroundService on the session bus

### DIFF
--- a/org.gnome.Weather.json
+++ b/org.gnome.Weather.json
@@ -15,6 +15,7 @@
     "--filesystem=xdg-run/dconf",
     "--filesystem=~/.config/dconf:ro",
     "--talk-name=ca.desrt.dconf",
+    "--own-name=org.gnome.Weather.BackgroundService",
     "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
   ],
   "build-options" : {


### PR DESCRIPTION
As we changed the application's ID to org.gnome.Weather.Application,
this service's name is no longer a subdomain of the application's ID
and so we need to explicitly allow GNOME Weather owning it on the
session bus for it to properly work.

https://phabricator.endlessm.com/T15906